### PR TITLE
Skip empty sections when rendering Apple News components

### DIFF
--- a/lib/renderers/apple-news.js
+++ b/lib/renderers/apple-news.js
@@ -168,6 +168,10 @@ export default class Renderer {
     tagName = tagName.toLowerCase();
 
     let html = this.renderMarkersToHTML(markers);
+    if (html.length === 0) {
+      // Apple News format does not allow components with blank (zero-length) text
+      return;
+    }
     let component = {
       role: TAG_NAME_TO_AN_ROLE[tagName] || TAG_NAME_TO_AN_ROLE.__default__,
       text: html,

--- a/tests/unit/renderers/apple-news-renderer-test.js
+++ b/tests/unit/renderers/apple-news-renderer-test.js
@@ -128,3 +128,10 @@ test('mobiledoc with cards throws on invalid return value', function(assert) {
     let rendered = render(mobiledoc, {cards: [card]}); // jshint ignore:line
   }, /"role" property/);
 });
+
+test('mobiledoc with empty section is not included in Apple News output', function(assert) {
+  let mobiledoc = createSimpleMobiledoc({text: ''});
+  let rendered = render(mobiledoc);
+  let { result: { components } } = rendered;
+  assert.equal(components.length, 0, 'empty section is not included in component output');
+});


### PR DESCRIPTION
Apple News format doesn't allow components with blank text strings ("").