### PR TITLE
Adds list sections and list items renderer

### DIFF
--- a/lib/renderers/apple-news.js
+++ b/lib/renderers/apple-news.js
@@ -1,6 +1,7 @@
 import {
   MARKUP_SECTION_TYPE,
-  CARD_SECTION_TYPE
+  CARD_SECTION_TYPE,
+  LIST_SECTION_TYPE
 } from '../utils/section-types';
 import RENDER_TYPE from '../utils/render-type';
 import {
@@ -93,6 +94,8 @@ export default class Renderer {
         return this.renderMarkupSection(section);
       case CARD_SECTION_TYPE:
         return this.renderCardSection(section);
+      case LIST_SECTION_TYPE:
+        return this.renderListSection(section);
     }
   }
 
@@ -101,6 +104,30 @@ export default class Renderer {
     let cardArg = this._createCardArgument(card, payload);
     let component = card.render(cardArg);
     this._assertValidComponent(component, card);
+    return component;
+  }
+
+  renderListItem(markers) {
+    const element = this.dom.createElement('li');
+    this.renderMarkersToHTML(markers, element);
+    return element;
+  }
+
+  renderListSection([type, tagName, listItems]) {
+    const element = this.dom.createElement(tagName);
+    listItems.forEach(li => {
+      element.appendChild(this.renderListItem(li));
+    });
+    const html = this.htmlSerializer(element);
+    if (html.trim().length === 0) {
+      // Apple News format does not allow components with blank (zero-length) text
+      return;
+    }
+    let component = {
+      role: TAG_NAME_TO_AN_ROLE[tagName] || TAG_NAME_TO_AN_ROLE.__default__,
+      text: html,
+      format: 'html'
+    };
     return component;
   }
 
@@ -183,8 +210,8 @@ export default class Renderer {
   /**
    * @return {string} html
    */
-  renderMarkersToHTML(markers) {
-    let currentElement = this.dom.createElement('p');
+  renderMarkersToHTML(markers, element) {
+    let currentElement = element || this.dom.createElement('p');
     let elements = [currentElement];
 
     let pushElement = (openedElement) => {


### PR DESCRIPTION
This returns things like:

```
  { role: 'body',
    text:
     '<li>East Renfrewshire </li><li>East Dunbartonshire</li><li>Aberdeenshire</li><li>Stirling</li><li>Scottish Borders</li><li>Midlothian</li><li>East Lothian</li><li>Highland</li><li>South Ayrshire</li><li>Shetland Islands</li>',
    format: 'html' },
```

Not sure if that's right but seems pretty good